### PR TITLE
Ignore the store shelf collider in Raycast

### DIFF
--- a/src/Internals/Raycast.cs
+++ b/src/Internals/Raycast.cs
@@ -66,9 +66,17 @@ public class ItemShopRaycast : MonoBehaviour
         bool lmb = Input.GetMouseButtonDown(0);
         bool rmb = Input.GetMouseButtonDown(1);
 
-        if (!string.IsNullOrEmpty(UnifiedRaycast.GetHitName()))
+        var hitName = UnifiedRaycast.GetHitName();
+        if (!string.IsNullOrEmpty(hitName))
         {
-            hit = UnifiedRaycast.GetRaycastHit();
+            if (hitName == "store_equipment")
+            {
+                RaycastHit[] hits = UnifiedRaycast.GetRaycastHits();
+                if (hits.Length < 2) return;
+                hit = hits[1];
+            }
+            else
+                hit = UnifiedRaycast.GetRaycastHit();
 
             if (ItemShop.ShopLookup.TryGetValue(hit.collider, out ItemShop shop))
             {

--- a/src/Internals/Raycast.cs
+++ b/src/Internals/Raycast.cs
@@ -19,9 +19,6 @@ public class ItemShopRaycast : MonoBehaviour
 
     private RaycastHit hit;
 
-    // DEBUG
-    private RaycastHit[] hits;
-
     private IEnumerator ToggleESBool() // Due to load order depending on the dll names (alphabetical order), the script needs to wait until ExpandedShop instantiated its components
     {
         GameObject es;

--- a/src/Internals/Raycast.cs
+++ b/src/Internals/Raycast.cs
@@ -19,6 +19,9 @@ public class ItemShopRaycast : MonoBehaviour
 
     private RaycastHit hit;
 
+    // DEBUG
+    private RaycastHit[] hits;
+
     private IEnumerator ToggleESBool() // Due to load order depending on the dll names (alphabetical order), the script needs to wait until ExpandedShop instantiated its components
     {
         GameObject es;
@@ -72,7 +75,15 @@ public class ItemShopRaycast : MonoBehaviour
             if (hitName == "store_equipment")
             {
                 RaycastHit[] hits = UnifiedRaycast.GetRaycastHits();
-                if (hits.Length < 2) return;
+                if (hits.Length < 2)
+                {
+                    if (cartIconShowing)
+                    {
+                        cartIconShowing = _guiBuy.Value = false;
+                        _guiText.Value = String.Empty;
+                    }
+                    return;
+                }
                 hit = hits[1];
             }
             else
@@ -84,9 +95,11 @@ public class ItemShopRaycast : MonoBehaviour
                 _guiText.Value = $"{shop.ItemName} {shop.ItemPrice} mk";
                 if (lmb && shop.Stock > 0) shop.Buy();
                 else if (rmb && shop.Cart > 0) shop.Unbuy();
+                return;
             }
         }
-        else if (cartIconShowing)
+
+        if (cartIconShowing)
         {
             cartIconShowing = _guiBuy.Value = false;
             _guiText.Value = String.Empty;

--- a/src/Internals/Raycast.cs
+++ b/src/Internals/Raycast.cs
@@ -72,6 +72,8 @@ public class ItemShopRaycast : MonoBehaviour
             if (hitName == "store_equipment")
             {
                 RaycastHit[] hits = UnifiedRaycast.GetRaycastHits();
+                Array.Sort(hits, (x, y) => x.distance.CompareTo(y.distance));
+
                 if (hits.Length < 2)
                 {
                     if (cartIconShowing)


### PR DESCRIPTION
Currently the mod developer must have the ItemShop collider sticking out a little from the store_equipment collider in order to trigger the interaction, but the player can't interact if they're aiming towards the center of the collider from the top or sides. 

I think it would be better if that collider was ignored by Raycast.cs completely, while continuing to detect any other collisions (like the store walls, slot machine, etc). This PR aims to accomplish that.